### PR TITLE
Add missing label

### DIFF
--- a/src/nakai.gleam
+++ b/src/nakai.gleam
@@ -40,7 +40,7 @@ pub fn render_with_document_attrs(root: Node(a), attrs: List(Attr(a))) -> String
   |> string_builder.to_string
 }
 
-pub fn render_with_doctype(doctype doctype: Doctype, root: Node(a)) -> String {
+pub fn render_with_doctype(doctype doctype: Doctype, root root: Node(a)) -> String {
   string_builder.concat([
     render.render_doctype(doctype),
     string_builder.from_string("\n"),


### PR DESCRIPTION
Hello!

With the latest Gleam will emit an error if a label is used before an unlabelled argument. This was always invalid, but the compiler would silently move on rather than letting you know.

Cheers,
Louis